### PR TITLE
Use a list if possible, lots of headobject calls are slow

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -2,6 +2,15 @@
 
 set -eu -o pipefail
 
+s3_list() {
+  local bucket="$1"
+  local aws_s3_args=("--region=$AWS_DEFAULT_REGION")
+
+  if ! aws s3 ls "${aws_s3_args[@]}" --recursive "s3://${bucket}" ; then
+    return 1
+  fi | awk '{print $4}'
+}
+
 s3_exists() {
   local bucket="$1"
   local key="$2"
@@ -10,6 +19,21 @@ s3_exists() {
   if ! aws s3api head-object "${aws_s3_args[@]}" --bucket "$bucket" --key "$key" &>/dev/null ; then
     return 1
   fi
+}
+
+has_secrets_key() {
+  local key="$1"
+
+  if [[ -n "$s3_bucket_listable" && ${#s3_bucket_list[@]} -gt 0 ]] ; then
+    for object in "${s3_bucket_list[@]}" ; do
+      if [[ "$object" == "$key" ]] ; then
+        return 0
+      fi
+    done
+    return 1
+  fi
+
+  s3_exists "$s3_bucket" "$key"
 }
 
 s3_download() {
@@ -30,19 +54,39 @@ safe_env_export() {
   sed -E -n 's/[^#]+/export &/ p'
 }
 
+add_ssh_private_key_to_agent() {
+  local ssh_key="$1"
+
+  if [[ -z "${SSH_AGENT_PID:-}" ]] ; then
+    echo "~~~ Starting an ephemeral ssh-agent" >&2;
+    eval "$(ssh-agent -s)"
+  fi
+
+  echo "~~~ Loading ssh-key into ssh-agent (pid ${SSH_AGENT_PID:-})" >&2;
+  SSH_ASKPASS="/bin/false" ssh-add <(echo "$ssh_key")
+}
+
 if [[ -z "${AWS_DEFAULT_REGION:-}" ]] ; then
   export AWS_DEFAULT_REGION=us-east-1
 fi
 
 s3_bucket="${BUILDKITE_PLUGIN_SECRETS_S3_BUCKET:-}"
 s3_bucket_prefix="${BUILDKITE_PLUGIN_SECRETS_S3_BUCKET_PREFIX:-$BUILDKITE_PIPELINE_SLUG}"
+s3_bucket_listable=
+s3_bucket_list=()
+ls_output=
 
-echo "Starting an SSH Agent..."
-eval "$(ssh-agent -s)"
-echo
+echo "~~~ Listing keys in :s3: $s3_bucket" >&2;
+if ls_output="$(s3_list "$s3_bucket")" ; then
+  s3_bucket_listable=1
+  declare -a 's3_bucket_list=('"$ls_output"')'
+  echo "LISTABLE"
+else
+  echo "~~~ :warning: Failed to list keys" >&2;
+fi
 
 if [[ -n "$s3_bucket" ]] ; then
-  echo "~~~ Downloading secrets from s3 bucket $s3_bucket" >&2;
+  echo "~~~ Downloading secrets from :s3: $s3_bucket" >&2;
 
   ssh_key_paths=(
     "$s3_bucket_prefix/private_ssh_key"
@@ -52,14 +96,13 @@ if [[ -n "$s3_bucket" ]] ; then
   )
 
   for key in ${ssh_key_paths[*]} ; do
-    if s3_exists "${s3_bucket}" "$key" ; then
+    if has_secrets_key "$key" ; then
       echo "~~~ Downloading ssh-key from ${key}" >&2;
       if ! ssh_key=$(s3_download "${s3_bucket}" "$key") ; then
         echo "~~~ :warning: Failed to download ssh-key $key" >&2;
         exit 1
       fi
-      echo "~~~ Loading ssh-key into ssh-agent ${SSH_AGENT_PID:-}" >&2;
-      SSH_ASKPASS="/bin/false" ssh-add <(echo "$ssh_key")
+      add_ssh_private_key_to_agent "$ssh_key"
       key_found=1
     fi
   done
@@ -79,7 +122,7 @@ if [[ -n "$s3_bucket" ]] ; then
   env_before="$(env | sort)"
 
   for key in ${env_paths[*]} ; do
-    if s3_exists "${s3_bucket}" "$key" ; then
+    if has_secrets_key "$key" ; then
       echo "~~~ Downloading env file from $key" >&2;
       if ! envvars=$(s3_download "${s3_bucket}" "$key") ; then
         echo "~~~ :warning: Failed to download env from $key" >&2;
@@ -100,14 +143,15 @@ if [[ -n "$s3_bucket" ]] ; then
   )
 
   for key in ${git_credentials_paths[*]} ; do
-    if s3_exists "${s3_bucket}" "$key" ; then
+    if has_secrets_key "$key" ; then
       echo "~~~ Downloading git-credentials files" >&2;
       if ! envvars=$(s3_download "${s3_bucket}" "$key") ; then
         echo "~~~ :warning: Failed to download git-credentials from $key" >&2;
         exit 1
       fi
-      echo "$key" > .git-credentials
-      git config credential.helper "store --file=$PWD/.git-credentials"
+      git_credentials="$(mktemp "$PWD/git-credentials.XXXXXXXXXXX")"
+      echo "$key" > "$git_credentials"
+      git config credential.helper "store --file=$git_credentials"
     fi
   done
 fi

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-ssh-agent -k
+if [[ -n "${SSH_AGENT_PID:-}" ]] ; then
+  ssh-agent -k
+fi

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -7,7 +7,43 @@ load '/usr/local/lib/bats/load.bash'
 # export SSH_AGENT_STUB_DEBUG=/dev/tty
 # export GIT_STUB_DEBUG=/dev/tty
 
+generate_file_list() {
+  echo \'
+  for file in "$@" ; do
+    echo -e "2013-09-02 21:37:53\t10 ${file}\n"
+  done
+  echo \'
+}
+
 @test "Load env file from s3 bucket" {
+  export BUILDKITE_PLUGIN_SECRETS_S3_BUCKET=my_secrets_bucket
+  export BUILDKITE_PLUGIN_SECRETS_DUMP_ENV=true
+  export BUILDKITE_PIPELINE_SLUG=test
+
+  stub ssh-agent "-s : echo export SSH_AGENT_PID=224;"
+
+  stub aws \
+    "s3 ls --region=us-east-1 --recursive s3://my_secrets_bucket : echo -e '2013-09-02 21:37:53\t10 env\n2013-09-02 21:32:57\t23 private_ssh_key\n2013-09-02 21:32:58\t41 test/private_ssh_key\n'" \
+    "s3 cp --quiet --region=us-east-1 --sse aws:kms s3://my_secrets_bucket/private_ssh_key /dev/stdout : echo secret material" \
+    "s3 cp --quiet --region=us-east-1 --sse aws:kms s3://my_secrets_bucket/test/private_ssh_key /dev/stdout : echo secret material" \
+    "s3 cp --quiet --region=us-east-1 --sse aws:kms s3://my_secrets_bucket/env /dev/stdout : echo SECRET=24"
+
+  stub ssh-add \
+    "echo added ssh key 1" \
+    "echo added ssh key 2"
+
+  run $PWD/hooks/environment
+
+  assert_success
+  assert_output --partial "added ssh key 1"
+  assert_output --partial "added ssh key 2"
+  assert_output --partial "SECRET=24"
+
+  unstub ssh-agent
+  unstub ssh-add
+}
+
+@test "Load env file from s3 bucket (not listable)" {
   export BUILDKITE_PLUGIN_SECRETS_S3_BUCKET=my_secrets_bucket
   export BUILDKITE_PLUGIN_SECRETS_DUMP_ENV=true
   export BUILDKITE_PIPELINE_SLUG=test
@@ -15,6 +51,7 @@ load '/usr/local/lib/bats/load.bash'
   stub ssh-agent "-s : echo echo started ssh-agent"
 
   stub aws \
+    "s3 ls --region=us-east-1 --recursive s3://my_secrets_bucket : exit 1" \
     "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key test/private_ssh_key : exit 1" \
     "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key test/id_rsa_github : exit 1" \
     "s3api head-object --region=us-east-1 --bucket my_secrets_bucket --key private_ssh_key : exit 0" \
@@ -36,6 +73,34 @@ load '/usr/local/lib/bats/load.bash'
   assert_success
   assert_output --partial "started ssh-agent"
   assert_output --partial "added ssh key"
+  assert_output --partial "SECRET=24"
+
+  unstub ssh-agent
+  unstub ssh-add
+}
+
+@test "Load env file from s3 bucket" {
+  export BUILDKITE_PLUGIN_SECRETS_S3_BUCKET=my_secrets_bucket
+  export BUILDKITE_PLUGIN_SECRETS_DUMP_ENV=true
+  export BUILDKITE_PIPELINE_SLUG=test
+
+  stub ssh-agent "-s : echo export SSH_AGENT_PID=224;"
+
+  stub aws \
+    "s3 ls --region=us-east-1 --recursive s3://my_secrets_bucket : echo -e '2013-09-02 21:37:53\t10 env\n2013-09-02 21:32:57\t23 private_ssh_key\n2013-09-02 21:32:58\t41 test/private_ssh_key\n'" \
+    "s3 cp --quiet --region=us-east-1 --sse aws:kms s3://my_secrets_bucket/private_ssh_key /dev/stdout : echo secret material" \
+    "s3 cp --quiet --region=us-east-1 --sse aws:kms s3://my_secrets_bucket/test/private_ssh_key /dev/stdout : echo secret material" \
+    "s3 cp --quiet --region=us-east-1 --sse aws:kms s3://my_secrets_bucket/env /dev/stdout : echo SECRET=24"
+
+  stub ssh-add \
+    "echo added ssh key 1" \
+    "echo added ssh key 2"
+
+  run $PWD/hooks/environment
+
+  assert_success
+  assert_output --partial "added ssh key 1"
+  assert_output --partial "added ssh key 2"
   assert_output --partial "SECRET=24"
 
   unstub ssh-agent


### PR DESCRIPTION
Currently all config is checked in s3 with a `headobject` call. This PR adds an optimization that checks these files via `ls` if possible.